### PR TITLE
fix: missed owner_id on app registrations

### DIFF
--- a/src/sam.cr
+++ b/src/sam.cr
@@ -48,9 +48,10 @@ namespace "create" do
 
   desc "Creates an application"
   task "application" do |_, args|
+    authority = (args["authority"]? || abort "missing authority id").to_s
     name = (args["name"]? || "backoffice").to_s
     base = (args["base"]? || "http://localhost:8080").to_s
-    PlaceOS::Tasks.create_application(name, base)
+    PlaceOS::Tasks.create_application(authority, name, base)
   end
 
   desc "Creates a user"

--- a/src/tasks/entities.cr
+++ b/src/tasks/entities.cr
@@ -76,10 +76,14 @@ module PlaceOS::Tasks::Entities
   end
 
   def create_application(
+    authority : Model::Authority | String,
     name : String,
     base : String,
     scope : String? = nil
   )
+    authority = Model::Authority.find!(authority) if authority.is_a?(String)
+    authority_id = authority.id.as(String)
+
     redirect_uri = File.join(base, name, "oauth-resp.html")
     application_id = Digest::MD5.hexdigest(redirect_uri)
     scope = "public" if scope.nil? || scope.empty?
@@ -110,6 +114,7 @@ module PlaceOS::Tasks::Entities
     application.uid = application_id
     application.scopes = scope
     application.skip_authorization = true
+    application.owner_id = authority_id
 
     application.save!
     Log.info { {

--- a/src/tasks/initialization.cr
+++ b/src/tasks/initialization.cr
@@ -19,7 +19,7 @@ module PlaceOS::Tasks::Initialization
     application_base = "#{tls ? "https" : "http"}://#{domain}"
     authority = Entities.create_authority(name: application_name, domain: application_base)
     Entities.create_user(authority: authority, name: username, email: email, password: password, sys_admin: true)
-    Entities.create_application(name: application_name, base: application_base)
+    Entities.create_application(authority: authority, name: application_name, base: application_base)
 
     if development
       Log.info { "creating placeholder documents" }


### PR DESCRIPTION
Requires an authority to be specified when creating an app registration.

Fixes #3.