### PR TITLE
refactor: use branches for backoffice interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ app
 bin
 docs
 lib
+sam.cr

--- a/shard.lock
+++ b/shard.lock
@@ -54,7 +54,7 @@ shards:
 
   neuroplastic:
     git: https://github.com/spider-gazelle/neuroplastic.git
-    version: 1.6.0
+    version: 1.6.1
 
   openssl_ext:
     git: https://github.com/stakach/openssl_ext.git
@@ -62,11 +62,11 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 3.0.0
+    version: 3.1.1
 
   rethinkdb:
     git: https://github.com/kingsleyh/crystal-rethinkdb.git
-    version: 0.2.0
+    version: 0.2.1
 
   rethinkdb-orm:
     git: https://github.com/spider-gazelle/rethinkdb-orm.git
@@ -78,7 +78,7 @@ shards:
 
   sam:
     git: https://github.com/imdrasil/sam.cr.git
-    version: 0.3.2
+    version: 0.4.0
 
   simple_retry:
     git: https://github.com/spider-gazelle/simple_retry.git

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-init
-version: 0.6.0
+version: 0.7.0
 crystal: 0.35.1
 license: MIT
 

--- a/src/start.cr
+++ b/src/start.cr
@@ -9,6 +9,5 @@ module PlaceOS
     username: ENV["PLACE_USERNAME"]? || abort("missing PLACE_USERNAME"),
     password: ENV["PLACE_PASSWORD"]? || abort("missing PLACE_PASSWORD"),
     auth_host: ENV["PLACE_AUTH_HOST"]? || "auth",
-    development: ENV["ENV"]? == "development",
   )
 end

--- a/src/tasks.cr
+++ b/src/tasks.cr
@@ -5,4 +5,10 @@ module PlaceOS::Tasks
   include Database
   include Entities
   include Initialization
+
+  PROD = (ENV["ENV"]? || ENV["SG_ENV"]?) == "production"
+
+  def production?
+    PROD
+  end
 end

--- a/src/tasks/database.cr
+++ b/src/tasks/database.cr
@@ -7,7 +7,7 @@ require "../log"
 module PlaceOS::Tasks::Database
   extend self
   include RethinkDB::Shortcuts
-  Log = ::Log.for("tasks").for("database")
+  Log = ::Log.for(self)
 
   def drop_rethinkdb_tables(
     rethinkdb_db : String,

--- a/src/tasks/entities.cr
+++ b/src/tasks/entities.cr
@@ -6,7 +6,7 @@ require "../log"
 
 module PlaceOS::Tasks::Entities
   extend self
-  Log = ::Log.for("tasks").for("entities")
+  Log = ::Log.for(self)
 
   def create_authority(
     name : String,
@@ -34,6 +34,7 @@ module PlaceOS::Tasks::Entities
     folder_name : String,
     description : String,
     uri : String,
+    branch : String = "master",
     commit_hash : String = "HEAD"
   )
     existing = Model::Repository.where(

--- a/src/tasks/initialization.cr
+++ b/src/tasks/initialization.cr
@@ -3,7 +3,7 @@ require "../log"
 
 module PlaceOS::Tasks::Initialization
   extend self
-  Log = ::Log.for("tasks").for("initialization")
+  Log = ::Log.for(self)
 
   # Initialization script
   def start(
@@ -13,21 +13,22 @@ module PlaceOS::Tasks::Initialization
     email : String,
     username : String,
     password : String,
-    auth_host : String,
-    development : Bool
+    auth_host : String
   )
     application_base = "#{tls ? "https" : "http"}://#{domain}"
     authority = Entities.create_authority(name: application_name, domain: application_base)
     Entities.create_user(authority: authority, name: username, email: email, password: password, sys_admin: true)
     Entities.create_application(authority: authority, name: application_name, base: application_base)
+
     Entities.create_interface(
       name: "Backoffice",
       folder_name: "backoffice",
-      uri: "https://github.com/place-labs/backoffice-release",
+      uri: "https://github.com/placeos/backoffice",
+      branch: "build-#{PlaceOS::Tasks.production? ? "release" : "alpha"}",
       description: "Admin interface for PlaceOS",
     )
 
-    if development
+    unless PlaceOS::Tasks.production?
       Log.info { "creating placeholder documents" }
       Entities.create_placeholders
     end


### PR DESCRIPTION
Default to `backoffice-alpha` in development, `backoffice-release` in production