### PR TITLE
build(Dockerfile): reduce container bloat as tasks are now compiled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
 FROM crystallang/crystal:0.35.1-alpine
 
-# Install rethinkdb & python driver
-RUN apk add --update rethinkdb py-pip
-RUN pip install rethinkdb
-
 WORKDIR /scripts
-
-COPY Makefile Makefile
 
 COPY shard.yml shard.yml
 COPY shard.lock shard.lock
@@ -18,6 +12,14 @@ COPY src src
 RUN mkdir -p /scripts/bin
 ENV PATH="/scripts/bin:${PATH}"
 
-RUN shards build --production --error-trace --release
+RUN shards build --static --production --error-trace --release
 
-CMD ["/scripts/bin/start"]
+FROM alpine:3.11
+
+# Install rethinkdb & python driver
+RUN apk add --update rethinkdb py-pip
+RUN pip install rethinkdb
+
+COPY --from=0 /scripts/bin /scripts
+
+CMD ["/scripts/start"]

--- a/Dockerfile.rethinkdb-backup
+++ b/Dockerfile.rethinkdb-backup
@@ -1,2 +1,2 @@
 FROM placeos/init:latest
-CMD ["/scripts/bin/backup"]
+CMD ["/scripts/backup"]


### PR DESCRIPTION
We unfortunately need python to exfil the database...
That said, we could likely strip this container down further.