### PR TITLE
fix: alpine build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ COPY shard.yml .
 COPY shard.override.yml .
 COPY shard.lock .
 
-RUN shards install --static
+RUN shards install --production
 
 COPY src src
 
 RUN mkdir -p /app/bin
 
-RUN shards build --static --production --error-trace --release
+RUN shards build --static --error-trace --release
 
 FROM alpine:3.11
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM crystallang/crystal:0.36.1-alpine AS base
 
 WORKDIR /app
 
+RUN apk add --no-cache yaml-static
+
 COPY shard.yml .
 COPY shard.override.yml .
 COPY shard.lock .


### PR DESCRIPTION
Ensures that `yaml-static` is available to the compiler for static linking.

Installs shards with `--production` flag.