### PR TITLE
feat(kibana): set up Metrics tab showing Kibana in authority config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin
 docs
 lib
 sam.cr
+*.swp

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -22,7 +22,7 @@ module PlaceOS
   USERNAME         = ENV["PLACE_USERNAME"]? || abort("missing PLACE_USERNAME")
   PASSWORD         = ENV["PLACE_PASSWORD"]? || abort("missing PLACE_PASSWORD")
   AUTH_HOST        = ENV["PLACE_AUTH_HOST"]? || "auth"
-  KIBANA_ROUTE     = ENV["KIBANA_ROUTE"]? || "monitor"
+  METRICS_ROUTE     = ENV["PLACE_METRICS_ROUTE"]? || "monitor"
 
   # Resource configurations
 

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -22,6 +22,7 @@ module PlaceOS
   USERNAME         = ENV["PLACE_USERNAME"]? || abort("missing PLACE_USERNAME")
   PASSWORD         = ENV["PLACE_PASSWORD"]? || abort("missing PLACE_PASSWORD")
   AUTH_HOST        = ENV["PLACE_AUTH_HOST"]? || "auth"
+  KIBANA_ROUTE     = ENV["KIBANA_ROUTE"]? || "monitor"
 
   # Resource configurations
 

--- a/src/sam.cr
+++ b/src/sam.cr
@@ -80,8 +80,8 @@ namespace "create" do
     tls = (args["tls"]? || PlaceOS::TLS).try &.to_s.downcase == "true"
 
     site_origin = "#{tls ? "https" : "http"}://#{domain_name}"
-    kibana_url = "#{site_origin}/#{PlaceOS::KIBANA_ROUTE}/"
-    config = {"metrics" => JSON::Any.new(kibana_url)}
+    metrics_url = "#{site_origin}/#{PlaceOS::METRICS_ROUTE}/"
+    config = {"metrics" => JSON::Any.new(metrics_url)}
     PlaceOS::Tasks.create_authority(name: domain_name, domain: site_origin, config: config)
   end
 

--- a/src/sam.cr
+++ b/src/sam.cr
@@ -80,7 +80,9 @@ namespace "create" do
     tls = (args["tls"]? || PlaceOS::TLS).try &.to_s.downcase == "true"
 
     site_origin = "#{tls ? "https" : "http"}://#{domain_name}"
-    PlaceOS::Tasks.create_authority(name: domain_name, domain: site_origin)
+    kibana_url = "#{site_origin}/#{PlaceOS::KIBANA_ROUTE}/"
+    config = {"metrics" => JSON::Any.new(kibana_url)}
+    PlaceOS::Tasks.create_authority(name: domain_name, domain: site_origin, config: config)
   end
 
   desc "Creates an application"

--- a/src/start.cr
+++ b/src/start.cr
@@ -12,5 +12,6 @@ module PlaceOS
     username: USERNAME,
     password: PASSWORD,
     auth_host: AUTH_HOST,
+    kibana_route: KIBANA_ROUTE
   )
 end

--- a/src/start.cr
+++ b/src/start.cr
@@ -12,6 +12,6 @@ module PlaceOS
     username: USERNAME,
     password: PASSWORD,
     auth_host: AUTH_HOST,
-    kibana_route: KIBANA_ROUTE
+    metrics_route: METRICS_ROUTE
   )
 end

--- a/src/tasks/entities.cr
+++ b/src/tasks/entities.cr
@@ -10,13 +10,15 @@ module PlaceOS::Tasks::Entities
 
   def create_authority(
     name : String,
-    domain : String
+    domain : String,
+    config : Hash(String, JSON::Any)
   )
     upsert_document(Model::Authority.find_by_domain(domain)) do
       Log.info { {message: "creating Authority", name: name, domain: domain} }
       auth = Model::Authority.new
       auth.name = File.join(domain.lchop("https://").lchop("http://"), name)
       auth.domain = domain
+      auth.config = config
       auth
     end
   rescue e

--- a/src/tasks/initialization.cr
+++ b/src/tasks/initialization.cr
@@ -13,10 +13,13 @@ module PlaceOS::Tasks::Initialization
     email : String,
     username : String,
     password : String,
-    auth_host : String
+    auth_host : String,
+    kibana_route : String
   )
     application_base = "#{tls ? "https" : "http"}://#{domain}"
-    authority = Entities.create_authority(name: application_name, domain: application_base)
+    kibana_url = "#{application_base}/#{kibana_route}/"
+    metrics_config = {"metrics" => JSON::Any.new(kibana_url)}
+    authority = Entities.create_authority(name: application_name, domain: application_base, config: metrics_config)
     Entities.create_user(authority: authority, name: username, email: email, password: password, sys_admin: true)
     Entities.create_application(authority: authority, name: application_name, base: application_base)
 

--- a/src/tasks/initialization.cr
+++ b/src/tasks/initialization.cr
@@ -14,11 +14,11 @@ module PlaceOS::Tasks::Initialization
     username : String,
     password : String,
     auth_host : String,
-    kibana_route : String
+    metrics_route : String
   )
     application_base = "#{tls ? "https" : "http"}://#{domain}"
-    kibana_url = "#{application_base}/#{kibana_route}/"
-    metrics_config = {"metrics" => JSON::Any.new(kibana_url)}
+    metrics_url = "#{application_base}/#{metrics_route}/"
+    metrics_config = {"metrics" => JSON::Any.new(metrics_url)}
     authority = Entities.create_authority(name: application_name, domain: application_base, config: metrics_config)
     Entities.create_user(authority: authority, name: username, email: email, password: password, sys_admin: true)
     Entities.create_application(authority: authority, name: application_name, base: application_base)


### PR DESCRIPTION
Enables the Metrics tab by creating the `metrics` key in authority config during initialization and authority creation