### PR TITLE
improvement: clearer domain (`Authority`) name

### DIFF
--- a/src/constants.cr
+++ b/src/constants.cr
@@ -22,7 +22,7 @@ module PlaceOS
   USERNAME         = ENV["PLACE_USERNAME"]? || abort("missing PLACE_USERNAME")
   PASSWORD         = ENV["PLACE_PASSWORD"]? || abort("missing PLACE_PASSWORD")
   AUTH_HOST        = ENV["PLACE_AUTH_HOST"]? || "auth"
-  METRICS_ROUTE     = ENV["PLACE_METRICS_ROUTE"]? || "monitor"
+  METRICS_ROUTE    = ENV["PLACE_METRICS_ROUTE"]? || "monitor"
 
   # Resource configurations
 

--- a/src/migrations.cr
+++ b/src/migrations.cr
@@ -8,4 +8,3 @@ module Migrations
     {% end %}
   end
 end
-

--- a/src/migrations/1.2104-000-settings_parent_type.cr
+++ b/src/migrations/1.2104-000-settings_parent_type.cr
@@ -7,7 +7,7 @@ module Migrations::SettingParentType
     raw_query do |r|
       r
         .table(PlaceOS::Model::Settings.table_name)
-        .filter { |s| s["parent_type"].type_of.eq("NUMBER") }
+        .filter(&.["parent_type"].type_of.eq("NUMBER"))
         .update { |s|
           {% begin %}
             {% type = PlaceOS::Model::Settings::ParentType %}

--- a/src/tasks/entities.cr
+++ b/src/tasks/entities.cr
@@ -16,7 +16,7 @@ module PlaceOS::Tasks::Entities
     upsert_document(Model::Authority.find_by_domain(domain)) do
       Log.info { {message: "creating Authority", name: name, domain: domain} }
       auth = Model::Authority.new
-      auth.name = File.join(domain.lchop("https://").lchop("http://"), name)
+      auth.name = domain
       auth.domain = domain
       auth.config = config
       auth


### PR DESCRIPTION
Sets the `Authority`'s name to the domain. This reduces confusion on the coupling of domains to applications.

Fixes #27 