### PR TITLE
Update Backoffice branches

### DIFF
--- a/src/migration.cr
+++ b/src/migration.cr
@@ -5,6 +5,8 @@ module Migration
   macro included
     Log = ::Log.for(self)
 
+    Ref = __FILE__
+
     def self.raw_query(&)
       results = PlaceOS::Model::Connection.raw { |r| yield r }
       Log.info { results }

--- a/src/migrations.cr
+++ b/src/migrations.cr
@@ -2,7 +2,7 @@ require "./migrations/*"
 
 module Migrations
   def self.apply_all
-    {% for migration in Migration.includers.sort { |t| basename(filename t) } %}
+    {% for migration in Migration.includers.sort_by &.constant(:Ref) %}
       # FIXME: run version diffing for direction. Up only for now.
       {{migration}}.up
     {% end %}

--- a/src/migrations/1.2107-000-backoffice_branch.cr
+++ b/src/migrations/1.2107-000-backoffice_branch.cr
@@ -1,0 +1,26 @@
+require "../migration"
+
+module Migrations::BackofficeBranch
+  include Migration::Irreversible
+
+  BRANCH_NAMES = {
+    "build-release" => "build/prod",
+    "build-alpha"   => "build/dev",
+  }
+
+  def self.up
+    PlaceOS::Model::Repository.where(
+      uri: "https://github.com/placeos/backoffice"
+    ).each do |repo|
+      begin
+        if new_branch = BRANCH_NAMES[repo.branch]?
+          Log.info { "updating #{repo.id} (#{repo.branch} -> #{new_branch})" }
+          repo.branch = new_branch
+          repo.save!
+        end
+      rescue e
+        Log.error(exception: e) { "migration for #{repo.id} failed" }
+      end
+    end
+  end
+end

--- a/src/tasks/initialization.cr
+++ b/src/tasks/initialization.cr
@@ -27,7 +27,7 @@ module PlaceOS::Tasks::Initialization
       name: "Backoffice",
       folder_name: "backoffice",
       uri: "https://github.com/placeos/backoffice",
-      branch: "build/#{PlaceOS::Tasks.production? ? "prod" : "alpha"}",
+      branch: "build/#{PlaceOS::Tasks.production? ? "prod" : "dev"}",
       description: "Admin interface for PlaceOS",
     )
 


### PR DESCRIPTION
Branches used to publish backoffice builds updated some time ago (https://github.com/PlaceOS/backoffice/commit/fafdaa5c3b1eb6d5df414744c2d80f2ed568482f). This change was not captured here.

This PR corrects this, and provides a migration for systems using previous branch names.