### PR TITLE
feat(chronograf): Generate secrets for Chronograf running in a docker-compose environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,8 @@
 name: CI
 on: push
 jobs:
-  style:
-    runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal
-    steps:
-      - uses: actions/checkout@v2
-      - name: Format
-        run: crystal tool format --check
-      - name: Lint
-        uses: crystal-ameba/github-action@v0.2.12
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  crystal-style:
+    uses: PlaceOS/.github/.github/workflows/crystal-style.yml@main
+
+  dockerfile-style:
+    uses: PlaceOS/.github/.github/workflows/dockerfile-style.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+on: push
+jobs:
+  style:
+    runs-on: ubuntu-latest
+    container:
+      image: crystallang/crystal
+    steps:
+      - uses: actions/checkout@v2
+      - name: Format
+        run: crystal tool format --check
+      - name: Lint
+        uses: crystal-ameba/github-action@v0.2.12
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG CRYSTAL_VERSION=1.1.1
+ARG CRYSTAL_VERSION=1.2.2
 FROM crystallang/crystal:${CRYSTAL_VERSION}-alpine AS build
 WORKDIR /app
 
@@ -14,7 +14,11 @@ COPY src src
 
 RUN mkdir -p /app/bin
 
-RUN shards build --release --static --error-trace --ignore-crystal-version
+RUN shards build \
+    --error-trace \
+    --ignore-crystal-version \
+    --release \
+    --static
 
 # TODO: Stuck on 3.12 as `rethinkdb` is no longer packaged.
 FROM alpine:3.12
@@ -31,7 +35,7 @@ RUN apk add --no-cache \
         py-pip \
         rethinkdb
 
-RUN pip install rethinkdb
+RUN pip install --no-cache-dir "rethinkdb==2.4.8"
 
 COPY scripts /app/scripts
 

--- a/scripts/generate-secrets
+++ b/scripts/generate-secrets
@@ -38,7 +38,6 @@ if [[ -z "${INFLUX_API_KEY}" ]]; then
   INFLUX_API_KEY=$(openssl rand -base64 24)
   echo "INFLUX_API_KEY=${INFLUX_API_KEY}" > "$influx_key_env"   # for Source
   echo "INFLUXDB_TOKEN=${INFLUX_API_KEY}" >> "$influx_key_env"  # for Chronograf
-  echo "DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=${INFLUX_API_KEY}" >> "$influx_key_env"   # for InfluxDB docker image auto init
   echo "generated INFLUX_API_KEY"
 else
   echo "already generated INFLUX_API_KEY"

--- a/scripts/generate-secrets
+++ b/scripts/generate-secrets
@@ -24,7 +24,9 @@ if [[ -z "${INFLUX_API_KEY}" ]]; then
   INFLUX_API_KEY=$(openssl rand -base64 24)
 
   # Write the API key to an env file
-  echo "INFLUX_API_KEY=${INFLUX_API_KEY}" > "$influx_key_env"
+  echo "INFLUX_API_KEY=${INFLUX_API_KEY}" > "$influx_key_env"   # for Source
+  echo "INFLUXDB_TOKEN=${INFLUX_API_KEY}" >> "$influx_key_env"  # for Chronograf
+  echo "DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=${INFLUX_API_KEY}" >> "$influx_key_env"   # for InfluxDB docker image auto init
   echo "generated INFLUX_API_KEY"
 else
   echo "already generated INFLUX_API_KEY"

--- a/scripts/generate-secrets
+++ b/scripts/generate-secrets
@@ -2,6 +2,7 @@
 set -e
 
 influx_key_env=".env.influxdb"
+chronograf_token_secret=".env.chronograf"
 secret_key_env=".env.secret_key"
 public_key_env=".env.public_key"
 env=".env"
@@ -9,6 +10,9 @@ env=".env"
 set -a
 if [[ -f "${influx_key_env}" ]]; then
     . ${influx_key_env}
+fi
+if [[ -f "${chronograf_token_secret}" ]]; then
+    . ${chronograf_token_secret}
 fi
 if [[ -f "${secret_key_env}" ]]; then
     . ${secret_key_env}
@@ -20,10 +24,18 @@ fi
 . ${env}
 set +a
 
+if [[ -z "${TOKEN_SECRET}" ]]; then
+  TOKEN_SECRET=$(openssl rand -base64 256 | tr -d '\n')
+
+  # Write the new secret to an env file
+  echo "TOKEN_SECRET=${TOKEN_SECRET}" > "$chronograf_token_secret"
+  echo "generated Chrongraf TOKEN_SECRET"
+else
+  echo "already generated Chrongraf TOKEN_SECRET"
+fi
+
 if [[ -z "${INFLUX_API_KEY}" ]]; then
   INFLUX_API_KEY=$(openssl rand -base64 24)
-
-  # Write the API key to an env file
   echo "INFLUX_API_KEY=${INFLUX_API_KEY}" > "$influx_key_env"   # for Source
   echo "INFLUXDB_TOKEN=${INFLUX_API_KEY}" >> "$influx_key_env"  # for Chronograf
   echo "DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=${INFLUX_API_KEY}" >> "$influx_key_env"   # for InfluxDB docker image auto init
@@ -31,7 +43,6 @@ if [[ -z "${INFLUX_API_KEY}" ]]; then
 else
   echo "already generated INFLUX_API_KEY"
 fi
-
 
 if [[ -z "${JWT_PUBLIC}" || -z "${JWT_SECRET}" ]]; then
   dir=$(mktemp -d)

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -16,15 +16,15 @@ module PlaceOS
 
   # Initialization constants
 
-  APPLICATION_NAME = ENV["PLACE_APPLICATION"]? || "backoffice"
-  DOMAIN           = ENV["PLACE_DOMAIN"]? || "localhost:8080"
-  TLS              = ENV["PLACE_TLS"]?.try(&.downcase) == "true"
-  EMAIL            = ENV["PLACE_EMAIL"]? || abort("missing PLACE_EMAIL")
-  USERNAME         = ENV["PLACE_USERNAME"]? || abort("missing PLACE_USERNAME")
-  PASSWORD         = ENV["PLACE_PASSWORD"]? || abort("missing PLACE_PASSWORD")
-  AUTH_HOST        = ENV["PLACE_AUTH_HOST"]? || "auth"
-  METRICS_ROUTE    = ENV["PLACE_METRICS_ROUTE"]? || "monitor"
-  ANALYTICS_ROUTE  = ENV["PLACE_ANALYTICS_ROUTE"]? || "analytics"
+  APPLICATION_NAME        = ENV["PLACE_APPLICATION"]? || "backoffice"
+  DOMAIN                  = ENV["PLACE_DOMAIN"]? || "localhost:8080"
+  TLS                     = ENV["PLACE_TLS"]?.try(&.downcase) == "true"
+  EMAIL                   = ENV["PLACE_EMAIL"]? || abort("missing PLACE_EMAIL")
+  USERNAME                = ENV["PLACE_USERNAME"]? || abort("missing PLACE_USERNAME")
+  PASSWORD                = ENV["PLACE_PASSWORD"]? || abort("missing PLACE_PASSWORD")
+  AUTH_HOST               = ENV["PLACE_AUTH_HOST"]? || "auth"
+  METRICS_ROUTE           = ENV["PLACE_METRICS_ROUTE"]? || "monitor"
+  ANALYTICS_ROUTE         = ENV["PLACE_ANALYTICS_ROUTE"]? || "analytics"
   ANALYTICS_CALLBACK_PATH = ENV["ANALYTICS_CALLBACK_PATH"]? || "oauth/PlaceOS/callback"
 
   # Backoffice

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -24,6 +24,7 @@ module PlaceOS
   PASSWORD         = ENV["PLACE_PASSWORD"]? || abort("missing PLACE_PASSWORD")
   AUTH_HOST        = ENV["PLACE_AUTH_HOST"]? || "auth"
   METRICS_ROUTE    = ENV["PLACE_METRICS_ROUTE"]? || "monitor"
+  ANALYTICS_ROUTE  = ENV["PLACE_ANALYTICS_ROUTE"]? || "analytics"
 
   # Backoffice
 

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -25,6 +25,7 @@ module PlaceOS
   AUTH_HOST        = ENV["PLACE_AUTH_HOST"]? || "auth"
   METRICS_ROUTE    = ENV["PLACE_METRICS_ROUTE"]? || "monitor"
   ANALYTICS_ROUTE  = ENV["PLACE_ANALYTICS_ROUTE"]? || "analytics"
+  ANALYTICS_CALLBACK_PATH = ENV["ANALYTICS_CALLBACK_PATH"]? || "oauth/PlaceOS/callback"
 
   # Backoffice
 

--- a/src/start.cr
+++ b/src/start.cr
@@ -15,5 +15,6 @@ module PlaceOS
     metrics_route: METRICS_ROUTE,
     backoffice_branch: BACKOFFICE_BRANCH,
     backoffice_commit: BACKOFFICE_COMMIT,
+    analytics_route: ANALYTICS_ROUTE,
   )
 end

--- a/src/tasks/initialization.cr
+++ b/src/tasks/initialization.cr
@@ -29,7 +29,7 @@ module PlaceOS::Tasks::Initialization
 
     if analytics_route
       analytics_redirect_uri = File.join(application_base, analytics_route, ANALYTICS_CALLBACK_PATH)
-      Entities.create_application(authority: authority, name: analytics_route, base: application_base, redirect_uri: analytics_redirect_uri )
+      Entities.create_application(authority: authority, name: analytics_route, base: application_base, redirect_uri: analytics_redirect_uri)
     end
 
     Entities.create_interface(

--- a/src/tasks/initialization.cr
+++ b/src/tasks/initialization.cr
@@ -16,7 +16,8 @@ module PlaceOS::Tasks::Initialization
     auth_host : String,
     metrics_route : String,
     backoffice_branch : String,
-    backoffice_commit : String
+    backoffice_commit : String,
+    analytics_route : String? = nil
   )
     application_base = "#{tls ? "https" : "http"}://#{domain}"
     metrics_url = "#{application_base}/#{metrics_route}/"
@@ -25,6 +26,7 @@ module PlaceOS::Tasks::Initialization
 
     Entities.create_user(authority: authority, name: username, email: email, password: password, sys_admin: true)
     Entities.create_application(authority: authority, name: application_name, base: application_base)
+    Entities.create_application(authority: authority, name: analytics_route.not_nil!, base: application_base) if analytics_route
 
     Entities.create_interface(
       name: "Backoffice",

--- a/src/tasks/initialization.cr
+++ b/src/tasks/initialization.cr
@@ -26,7 +26,11 @@ module PlaceOS::Tasks::Initialization
 
     Entities.create_user(authority: authority, name: username, email: email, password: password, sys_admin: true)
     Entities.create_application(authority: authority, name: application_name, base: application_base)
-    Entities.create_application(authority: authority, name: analytics_route.not_nil!, base: application_base) if analytics_route
+
+    if analytics_route
+      analytics_redirect_uri = File.join(application_base, analytics_route, ANALYTICS_CALLBACK_PATH)
+      Entities.create_application(authority: authority, name: analytics_route, base: application_base, redirect_uri: analytics_redirect_uri )
+    end
 
     Entities.create_interface(
       name: "Backoffice",


### PR DESCRIPTION
This PR: 
1. Extends the automated secret generation for InfluxDB and does similar for Chronograf:
  a. Save the same INFLUX API KEY value to the same .env file but with an env var key that satisfies chronograf (the existing one satisfies Source)
  b. Generate a a`TOKEN_SECRET` as required by Chrongraf v1.9 for OAuth integration
2. Add an /analytics app by default, partially automating Chronograf Oauth integration (PlaceOS as the OAuth provider)

Feature 1 in this PR is a perquisite of https://github.com/place-labs/partner-environment/pull/80