### PR TITLE
feat(task): secret:rotate_server_secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ By default, the backup will take place at midnight every day.
     * `aws_secret`: Defaults to `AWS_SECRET`, required.
     * `aws_kms_key_id`: Defaults to `AWS_KMS_KEY_ID`
 
+- `secret:rotate_server_secret`: Rotate from old server secret to current value in `PLACE_SERVER_SECRET`
+    * `old_secret`: The previous value of `PLACE_SERVER_SECRET`, required.
+
 - `restore:rethinkdb`: Restore RethinkDB from S3.
     * `rethinkdb_host`: Defaults to `RETHINKDB_HOST` || `"localhost"`
     * `rethinkdb_port`: Defaults to `RETHINKDB_PORT` || `28019`

--- a/shard.lock
+++ b/shard.lock
@@ -91,7 +91,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 5.13.0
+    version: 5.14.0
 
   rethinkdb: # Overridden
     git: https://github.com/kingsleyh/crystal-rethinkdb.git

--- a/src/sam.cr
+++ b/src/sam.cr
@@ -71,9 +71,19 @@ end
 namespace "check" do
   desc "Check if a user exists on a domain"
   task "user" do |_, args|
-    email = (args["email"]? || abort "`email` not set").to_s
-    domain = (args["domain"]? || abort "`domain` not set").to_s
+    email = required_argument(args, "email").to_s
+    domain = required_argument(args, "domain").to_s
     exit(PlaceOS::Tasks.user_exists?(email, domain) ? 0 : 1)
+  end
+end
+
+namespace "secret" do
+  desc "Rotate the instance encryption secret"
+  task "rotate_server_secret" do |_, args|
+    abort("PLACE_SERVER_SECRET is unset") if ENV["PLACE_SERVER_SECRET"]?.presence.nil?
+
+    old_secret = required_argument(args, "old_secret").to_s
+    PlaceOS::Tasks.rotate_secret(old_secret)
   end
 end
 
@@ -102,7 +112,7 @@ namespace "create" do
   desc "Creates an application"
   task "application" do |_, args|
     arguments = {
-      authority:    (args["authority"]? || abort "missing authority id").to_s,
+      authority:    required_argument(args, "authority").to_s,
       name:         (args["name"]? || "backoffice").to_s,
       base:         (args["base"]? || "http://localhost:8080").to_s,
       redirect_uri: args["redirect_uri"]?.try &.to_s,
@@ -115,7 +125,7 @@ namespace "create" do
   desc "Creates a user"
   task "user" do |_, args_hash|
     arguments = {"authority_id", "email", "username", "password"}.map do |arg_key|
-      (args_hash[arg_key]?.try &.to_s) || abort "missing argument: `#{arg_key}`"
+      required_argument(args_hash, arg_key).to_s
     end
 
     sys_admin = args_hash["sys_admin"]?.try &.to_s.downcase == "true"
@@ -132,6 +142,10 @@ namespace "create" do
       support: support
     )
   end
+end
+
+def required_argument(args, key)
+  args[key]? || abort("missing argument `#{key}`")
 end
 
 Sam.help

--- a/src/tasks/secrets.cr
+++ b/src/tasks/secrets.cr
@@ -7,4 +7,44 @@ module PlaceOS::Tasks::Secrets
   def instance_secret_key
     Sodium::Sign::SecretKey.new.key.hexstring
   end
+
+  macro update_secret(old_secret, model, field, level, id)
+    %value = {{ model }}.{{ field.id }}
+    begin
+      unless %value.nil?
+        %secret = Encryption.decrypt(
+          string: %value,
+          level: {{ level }},
+          id: {{ id }},
+          secret: {{ old_secret }},
+        )
+        {{ model }}.{{ field.id }} = %secret
+        # Incomplete sanity check that the value was correctly decrypted
+        if %secret.valid_encoding?
+          {{ model }}.save!
+        else
+          Log.warn { "incorrectly decrypted secret for #{{{ model }}.id}" }
+        end
+      end
+    rescue error
+      Log.error(exception: error) { "failed to decrypt secret on #{{{ model }}.id}" }
+    end
+  end
+
+  def rotate_secret(old_secret : String)
+    Model::Edge.all.each do |model|
+      update_secret(old_secret, model, secret, Model::Edge::ENCRYPTION_LEVEL, "")
+    end
+
+    Model::Settings.all.each do |model|
+      level = model.encryption_level
+      encryption_id = model.parent_id.as(String)
+      update_secret(old_secret, model, settings_string, level, encryption_id)
+    end
+
+    Model::Repository.all.each do |model|
+      encryption_id = model.id.as(String)
+      update_secret(old_secret, model, password, Encryption::Level::NeverDisplay, encryption_id)
+    end
+  end
 end


### PR DESCRIPTION
Adds a task to rotate the encryption secret of an instance.
Use with the _utmost_ caution.
Please take a snapshot of the DB prior to running this task if the system is important in any way.