### PR TITLE
fix(generate-secrets): discards extra lines(logging) in `create:instance_key`

### DIFF
--- a/scripts/generate-secrets
+++ b/scripts/generate-secrets
@@ -111,7 +111,7 @@ fi
 
 if [[ -z "${PLACE_INSTANCE_TELEMETRY_KEY}" ]]; then
   PLACE_INSTANCE_TELEMETRY_KEY="$(LOG_LEVEL=NONE task create:instance_key)"
-  echo "PLACE_INSTANCE_TELEMETRY_KEY=${PLACE_INSTANCE_TELEMETRY_KEY}" >"$instance_telemetry_key_env"
+  echo "PLACE_INSTANCE_TELEMETRY_KEY=${PLACE_INSTANCE_TELEMETRY_KEY}" | grep "PLACE_INSTANCE_TELEMETRY_KEY=" >"$instance_telemetry_key_env"
   echo "generated PLACE_INSTANCE_TELEMETRY_KEY"
 else
   echo "already generated PLACE_INSTANCE_TELEMETRY_KEY"


### PR DESCRIPTION

A fix for the issue in [#201](https://github.com/place-technology/suncorp-ntt/issues/201):

This approach greps for the first line, which contains `PLACE_INSTANCE_TELEMETRY_KEY`
and the generated key, while discarding additional lines. 

Note: Seems like the [src/logging.cr](https://github.com/PlaceOS/init/blob/c9d9210d35b0c819ca5570c38be79cb15dba5e7b/src/logging.cr#L8) is appending logs to STDOUT. 
Another approach perhaps includes custom logs.