### PR TITLE
feat(migration): ensure user id prefixed by user table name

### DIFF
--- a/src/migrations/1.2204-001-user_id_prefix.cr
+++ b/src/migrations/1.2204-001-user_id_prefix.cr
@@ -1,0 +1,49 @@
+require "../migration"
+
+module RethinkDB
+  def self.json(json_string)
+    DatumTerm.new(TermType::JSON, [json_string])
+  end
+end
+
+module Migrations::MetadataJsonDetails
+  include Migration::Irreversible
+
+  def self.update(table, key, old_id, new_id)
+    raw_query do |r|
+      r
+        .table(table)
+        .filter(&.[key].eq(old_id))
+        .update { {key => new_id} }
+    end
+  end
+
+  def self.up
+    PlaceOS::Model::User.table_query do |q|
+      q.filter do |user|
+        user["id"].match("^#{PlaceOS::Model::User.table_name}").not
+      end
+    end.each do |user|
+      Log.info { "migrating User's id from #{user.id} to #{PlaceOS::Model::User.table_name}-#{user.id}" }
+      new_id = "#{PlaceOS::Model::User.table_name}-#{user.id}"
+      old_id = user.id.as(String)
+      user.id = new_id
+
+      {
+        {PlaceOS::Model::Metadata.table_name, "parent_id"},
+        {PlaceOS::Model::AssetInstance.table_name, "requester_id"},
+        {PlaceOS::Model::ApiKey.table_name, "user_id"},
+        {PlaceOS::Model::UserAuthLookup.table_name, "user_id"},
+        {"authentication", "user_id"},
+      }.each do |table, key|
+        update(table, key, old_id, new_id)
+      end
+
+      # Save the user _after_ migration relations.
+      # Ensures if there's a failure, subsequent runs will complete correctly.
+      user.save!
+    end
+  rescue e
+    Log.error(exception: e) { "failed to migrate User to prefixed id" }
+  end
+end

--- a/src/migrations/1.2204-001-user_id_prefix.cr
+++ b/src/migrations/1.2204-001-user_id_prefix.cr
@@ -13,10 +13,12 @@ module Migrations::UserIdPrefix
   end
 
   def self.up
-    PlaceOS::Model::User.table_query do |q|
-      q.filter do |user|
-        user["id"].match("^#{PlaceOS::Model::User.table_name}").not
-      end
+    PlaceOS::Model::User.raw_query do |q|
+      q
+        .table(PlaceOS::Model::User.table_name)
+        .filter do |user|
+          user["id"].match("^#{PlaceOS::Model::User.table_name}").not
+        end
     end.each do |user|
       Log.info { "migrating User's id from #{user.id} to #{PlaceOS::Model::User.table_name}-#{user.id}" }
       new_id = "#{PlaceOS::Model::User.table_name}-#{user.id}"

--- a/src/migrations/1.2204-001-user_id_prefix.cr
+++ b/src/migrations/1.2204-001-user_id_prefix.cr
@@ -1,12 +1,6 @@
 require "../migration"
 
-module RethinkDB
-  def self.json(json_string)
-    DatumTerm.new(TermType::JSON, [json_string])
-  end
-end
-
-module Migrations::MetadataJsonDetails
+module Migrations::UserIdPrefix
   include Migration::Irreversible
 
   def self.update(table, key, old_id, new_id)


### PR DESCRIPTION
**Description of the change**

Ensures that User IDs are prefixed by the user table name, in line with other models.

**Benefits**

Normalizes ID formats. Simplifies queries related to mixed ID fields.

**Possible drawbacks**

It's typically a smell to rely on the structure of an ID except for chronologically sorting results.

**Applicable issues**

- https://github.com/PlaceOS/auth/pull/66