### PR TITLE
feat(initialization): use `PLACE_SKIP_PLACEHOLDERS` to skip base entities

### DIFF
--- a/src/constants.cr
+++ b/src/constants.cr
@@ -29,6 +29,8 @@ module PlaceOS
   ANALYTICS_ROUTE         = ENV["PLACE_ANALYTICS_ROUTE"]? || "analytics"
   ANALYTICS_CALLBACK_PATH = ENV["ANALYTICS_CALLBACK_PATH"]? || "oauth/PlaceOS/callback"
 
+  SKIP_PLACEHOLDERS = self.boolean_env("PLACE_SKIP_PLACEHOLDERS")
+
   # Backoffice
 
   BACKOFFICE_BRANCH = ENV["PLACE_BACKOFFICE_BRANCH"]?.presence || "build/#{production? ? "prod" : "dev"}"

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -14,18 +14,19 @@ module PlaceOS
   AWS_S3_BUCKET  = ENV["AWS_S3_BUCKET"]?
   AWS_KMS_KEY_ID = ENV["AWS_KMS_KEY_ID"]?
 
-  RETHINKDB_FORCE_RESTORE = ENV["RETHINKDB_FORCE_RESTORE"]?.try(&.downcase) == "true"
+  RETHINKDB_FORCE_RESTORE = self.boolean_env("RETHINKDB_FORCE_RESTORE")
 
   # Initialization constants
 
-  APPLICATION_NAME        = ENV["PLACE_APPLICATION"]? || "backoffice"
-  DOMAIN                  = ENV["PLACE_DOMAIN"]? || "localhost:8080"
-  TLS                     = ENV["PLACE_TLS"]?.try(&.downcase) == "true"
-  EMAIL                   = ENV["PLACE_EMAIL"]? || abort("missing PLACE_EMAIL")
-  USERNAME                = ENV["PLACE_USERNAME"]? || abort("missing PLACE_USERNAME")
-  PASSWORD                = ENV["PLACE_PASSWORD"]? || abort("missing PLACE_PASSWORD")
-  AUTH_HOST               = ENV["PLACE_AUTH_HOST"]? || "auth"
-  METRICS_ROUTE           = ENV["PLACE_METRICS_ROUTE"]? || "monitor"
+  APPLICATION_NAME = ENV["PLACE_APPLICATION"]? || "backoffice"
+  DOMAIN           = ENV["PLACE_DOMAIN"]? || "localhost:8080"
+  TLS              = self.boolean_env("PLACE_TLS")
+  EMAIL            = ENV["PLACE_EMAIL"]? || abort("missing PLACE_EMAIL")
+  USERNAME         = ENV["PLACE_USERNAME"]? || abort("missing PLACE_USERNAME")
+  PASSWORD         = ENV["PLACE_PASSWORD"]? || abort("missing PLACE_PASSWORD")
+  AUTH_HOST        = ENV["PLACE_AUTH_HOST"]? || "auth"
+  METRICS_ROUTE    = ENV["PLACE_METRICS_ROUTE"]? || "monitor"
+
   ANALYTICS_ROUTE         = ENV["PLACE_ANALYTICS_ROUTE"]? || "analytics"
   ANALYTICS_CALLBACK_PATH = ENV["ANALYTICS_CALLBACK_PATH"]? || "oauth/PlaceOS/callback"
 
@@ -48,4 +49,8 @@ module PlaceOS
   RETHINKDB_PASS = ENV["RETHINKDB_PASS"]?
 
   class_getter? production : Bool = PROD
+
+  protected def self.boolean_env(key) : Bool
+    !!ENV[key]?.try(&.downcase.in?("1", "true"))
+  end
 end

--- a/src/tasks/initialization.cr
+++ b/src/tasks/initialization.cr
@@ -51,7 +51,7 @@ module PlaceOS::Tasks::Initialization
         description: "Admin interface for PlaceOS",
       )
 
-      unless PlaceOS::Tasks.production?
+      unless PlaceOS::Tasks.production? || PlaceOS::SKIP_PLACEHOLDERS
         Log.info { "creating placeholder documents" }
         Entities.create_placeholders
       end


### PR DESCRIPTION
**Description of the change**

Allow the user to skip entity creation in a development environment.
Base entities are default skipped in production environments.