### PR TITLE
chore(postgres): use postgresql 16 client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN apk add \
   'libcurl>=7.79.1-r0' \
   openssh \
   openssl \
-  postgresql15-client
+  postgresql16-client
 
 # copy app
 COPY scripts /app/scripts


### PR DESCRIPTION
Update the postgresql client from 15 ->16

Client version 15 cannot `pg_dump` from postgres 16

This may break backup jobs on postgres 15
- Untested if client can `pg_dump` from lower postgres versions, though it is recommended to use the same major version