### PR TITLE
feat(postgres): postgres 17 client

### DIFF
--- a/.github/workflows/postgres-versions.yml
+++ b/.github/workflows/postgres-versions.yml
@@ -1,0 +1,35 @@
+name: Update Postgres Version Branches
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update-postgres-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Need full history for merging
+
+      - name: Set up Git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "github-actions@github.com"
+
+      - name: Merge master into postgresql-15
+        run: |
+          git checkout postgresql-15
+          git merge --no-ff master -m "Merge master into postgresql-15"
+          sed -i 's/apk add postgresql[0-9]*-client/apk add postgresql15-client/g' Dockerfile
+          git commit -am "Ensure postgresql15-client is maintained" || echo "No changes to commit"
+          git push origin postgresql-15
+
+      - name: Merge master into postgresql-16
+        run: |
+          git checkout postgresql-16
+          git merge --no-ff master -m "Merge master into postgresql-16"
+          sed -i 's/apk add postgresql[0-9]*-client/apk add postgresql16-client/g' Dockerfile
+          git commit -am "Ensure postgresql16-client is maintained" || echo "No changes to commit"
+          git push origin postgresql-16

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN for binary in /app/bin/*; do \
 RUN git clone https://github.com/PlaceOS/models
 
 # Build a minimal docker image
-FROM alpine:3.20
+FROM alpine:3.21
 
 WORKDIR /app
 
@@ -59,7 +59,7 @@ RUN apk add \
   'libcurl>=7.79.1-r0' \
   openssh \
   openssl \
-  postgresql15-client
+  postgresql17-client
 
 # copy app
 COPY scripts /app/scripts

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 A set of scripts for initialization of PlaceOS.
 
+## Database Compatibility
+
+PostgreSQL 17 is recommended (and required by `placeos/init` image)
+
+PostgreSQL 15 & 16 compatible images are also available: `placeos/init_pg15`, `placeos/init_pg16`
+
+The PostgreSQL client version must match the PostgreSQL server's major version for backup tasks to function.
+
 ## Usage
 
 The scripts are methods wrapped by a [sam.cr](https://github.com/imdrasil/sam.cr) interface. Most use named arguments which are used as [described here](https://github.com/imdrasil/sam.cr#tasks-with-arguments).


### PR DESCRIPTION
Update postgres client to postgres version 17

Requires postgres 17 deployed
images for postgres 15 and 16 will be built seperately `init_pg15`, `init_pg16`