### PR TITLE
feat: remove Elasticsearch drop task and constants (PPT-2644)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,12 +240,8 @@ By default, the backup will take place at midnight every day.
     * `az_container`: Defaults to `AZURE_STORAGE_CONTAINER`, required.
     * `az_blob_object`: Object to restore DB from. Defaults to `AZURE_STORAGE_BLOB_OBJECT`, required.
 
-- `drop`: Drops Elasticsearch and PostgreSQL DB
-    * Runs `drop:elastic` and `drop:db` via environmental configuration
-
-- `drop:elastic`: Deletes all elastic indices tables
-    * `host`: Defaults to `ES_HOST` || `"localhost"`
-    * `port`: Defaults to `ES_PORT` || `9200`
+- `drop`: Drops the PostgreSQL DB
+    * Runs `drop:db` via environmental configuration
 
 - `drop:db`: Drops all PostgreSQL DB tables
     * `db`: Defaults `PG_DB` || `"postgres"`

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -47,9 +47,6 @@ module PlaceOS
 
   # Resource configurations
 
-  ES_HOST = ENV["ES_HOST"]? || "localhost"
-  ES_PORT = ENV["ES_PORT"]?.try &.to_i || 9200
-
   PG_DB   = ENV["PG_DB"]? || "postgres"
   PG_HOST = ENV["PG_HOST"]? || "localhost"
   PG_PORT = ENV["PG_PORT"]?.try &.to_i || 5432

--- a/src/sam.cr
+++ b/src/sam.cr
@@ -215,18 +215,11 @@ namespace "migrate" do
   end
 end
 
-desc "Drops Elasticsearch and PostgreSQL DB"
-task "drop", %w[drop:db drop:elastic] do
+desc "Drops the PostgreSQL DB"
+task "drop", %w[drop:db] do
 end
 
 namespace "drop" do
-  desc "Deletes all elastic indices tables"
-  task "elastic" do |_, args|
-    host = (args["host"]? || PlaceOS::ES_HOST).to_s
-    port = (args["port"]? || PlaceOS::ES_PORT).to_i
-    PlaceOS::Tasks.drop_elastic_indices(host, port)
-  end
-
   desc "Drops all PostgreSQL DB tables"
   task "db" do |_, args|
     arguments = {

--- a/src/tasks/database.cr
+++ b/src/tasks/database.cr
@@ -126,16 +126,6 @@ module PlaceOS::Tasks::Database
     PgORM::Database.exec_sql(sql)
   end
 
-  def drop_elastic_indices(elastic_host : String, elastic_port : Int32)
-    uri = URI.new(
-      host: elastic_host,
-      port: elastic_port,
-      path: "/_all",
-      scheme: "http"
-    )
-    HTTP::Client.delete(uri)
-  end
-
   def migrate_rethink_to_pg(
     path : String,
     pg_host : String,


### PR DESCRIPTION
Part of [PPT-2644](https://acaprojects.atlassian.net/browse/PPT-2644): PlaceOS search now runs on PostgreSQL full-text search. rest-api no longer reads Elasticsearch (in nightly images since 2026-08-12), so there are no ES indices for init to manage.

## What

- Removes the `drop:elastic` sam task and `Tasks.drop_elastic_indices`; `drop` now only runs `drop:db`.
- Removes the `ES_HOST` / `ES_PORT` constants from `src/constants.cr`.
- README: drops the `drop:elastic` rows and updates the `drop` description.

## Verification

- Rebased onto current master (v0.32.1); zero conflicts.
- `crystal build --no-codegen` passes on `src/sam.cr` and all three shard targets (`src/start.cr`, `src/backup.cr`, `src/restore.cr`).
- `grep -riE 'elastic|search[-_]ingest|neuroplastic|reindex|ES_HOST|ES_PORT'` over `src/`, `spec/`, and the README returns nothing.

## Merge order

Pairs with [PlaceOS/local#145](https://github.com/PlaceOS/local/pull/145) — its `hard_reset` currently invokes the `drop:elastic` task this PR removes — so ship both in the same release window.


[PPT-2644]: https://acaprojects.atlassian.net/browse/PPT-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ